### PR TITLE
Removed mutating keyword before getScore()

### DIFF
--- a/Quizzler-iOS13/Model/QuizBrain.swift
+++ b/Quizzler-iOS13/Model/QuizBrain.swift
@@ -39,7 +39,7 @@ struct QuizBrain {
         return Float(questionNumber) / Float(quiz.count)
     }
     
-    mutating func getScore() -> Int {
+    func getScore() -> Int {
         return score
     }
     


### PR DESCRIPTION
getScore() function is not modifying the internal score property of the Struct. 
mutating keyword might confuse students. Hence removed it.